### PR TITLE
More XDG respection, improved default path detection...

### DIFF
--- a/scripts/vh.in
+++ b/scripts/vh.in
@@ -685,19 +685,51 @@ function install()
 	# Select path where to put verlihub config file
 	IS_CHOOSEN_FOLDER_OK=false
 
+	declare -A FOLDERS;
+	FCOUNT=0;
+	IS_VH_CFG_NEEDS_CHOWN=false
+	VH_USER_DIR=""
+
+	if [ $EUID -eq 0 ]; then
+		FCOUNT=$(expr $FCOUNT + 1);
+		FOLDERS[$FCOUNT]="/etc/verlihub";
+		FCOUNT=$(expr $FCOUNT + 1);
+		FOLDERS[$FCOUNT]="$PREFIX/etc/verlihub";
+		GETENT=$(which getent);
+		if [ -n $GETENT ]; then
+			VH_USER_DIR=$($GETENT passwd verlihub | awk -F: '{print $6}');
+			if [ -n "$VH_USER_DIR" ]; then
+				IS_VH_CFG_NEEDS_CHOWN=true
+				FCOUNT=$(expr $FCOUNT + 1);
+				FOLDERS[$FCOUNT]="$VH_USER_DIR";
+			fi
+		fi
+	else
+		echo_s "\nRun vh --install as " $BLUE_BOLD;
+		echo_s "root" $RED_BOLD;
+		echo_s " to perfom system-wide setup" $BLUE_BOLD;
+		echo "";
+		FCOUNT=$(expr $FCOUNT + 1);
+		FOLDERS[$FCOUNT]="$HOME/.config/verlihub";
+		if [ -d "$HOME/.verlihub" ]; then
+			FCOUNT=$(expr $FCOUNT + 1);
+			FOLDERS[$FCOUNT]="$HOME/.verlihub";
+		fi
+	fi
+
 	until $IS_CHOOSEN_FOLDER_OK;
 	do
 		echo_s "\n-- You need to choose a place for the configuration files\n" $RED_BOLD;
-		echo_s "\t[1] " $BOLD && echo "/etc/verlihub"
-		echo_s "\t[2] " $BOLD && echo "$HOME/.verlihub"
-		echo_s "\t[3] " $BOLD && echo "$PREFIX/etc/verlihub"
-		echo_s "\t[4] " $BOLD && echo "Other, choose path where put config file"
+		for i in `seq 1 $FCOUNT`; do
+			echo_s "\t[$i] " $BOLD && echo ${FOLDERS[$i]}
+		done
+		echo_s "\t[9] " $BOLD && echo "Other, choose path where put config file"
 
 		local VALIDATE=false
 		until $VALIDATE
 		do	
 			local CHOOSEN_FOLDER=$(ask "Select number")
-			if [ "$CHOOSEN_FOLDER" = 1 ] || [ "$CHOOSEN_FOLDER" = 2 ] || [ "$CHOOSEN_FOLDER" = 3 ] || [ "$CHOOSEN_FOLDER" = 4 ]; then
+			if [ -n "${FOLDERS[$CHOOSEN_FOLDER]}" ] || [ "$CHOOSEN_FOLDER" == "9" ]; then
 				VALIDATE=true
 			else
 				echo_s "-- Insert a valid number from the list\n" $RED
@@ -705,13 +737,12 @@ function install()
 		done
 
 		# Get selected folder
-		case $CHOOSEN_FOLDER in
-			"1") CHOOSEN_FOLDER="/etc/verlihub/";;
-			"2") CHOOSEN_FOLDER="$HOME/.verlihub/";;
-			"3") CHOOSEN_FOLDER="$PREFIX/etc/verlihub/";;
-			"4") CHOOSEN_FOLDER=$(ask "Type complete path");
-		esac
-	
+		if [ -n "${FOLDERS[$CHOOSEN_FOLDER]}" ]; then
+			CHOOSEN_FOLDER="${FOLDERS[$CHOOSEN_FOLDER]}";
+		elif [ "$CHOOSEN_FOLDER" == "9" ]; then
+			CHOOSEN_FOLDER=$(ask "Type complete path");
+		fi
+
 		CHOOSEN_FOLDER_NOT_EXISTS=false
 		if [ -d $CHOOSEN_FOLDER ]; then
 			echo -n "-- The folder '$CHOOSEN_FOLDER' already exists (existing configuration will be backup). "
@@ -772,6 +803,11 @@ function install()
 	mkdir -p $CHOOSEN_FOLDER/plugins
 	mkdir -p $CHOOSEN_FOLDER/scripts
         ln -s $PLUGINDIR/libplug_pi.so $CHOOSEN_FOLDER/plugins
+
+	if $IS_VH_CFG_NEEDS_CHOWN && [ "$CHOOSEN_FOLDER" == "$VH_USER_DIR" ]; then
+		chown -R verlihub "$CHOOSEN_FOLDER";
+		chmod 0750 "$CHOOSEN_FOLDER";
+	fi
 
 	# Check if file has been created correctly
 	[ -f $CONFIG ] && CONFIG_EXISTS=true || CONFIG_EXISTS=false

--- a/scripts/vh_gui.in
+++ b/scripts/vh_gui.in
@@ -81,15 +81,34 @@ function _ask_admin_access()
 
 function _choose_folder() #title, #message
 {
+	FOLDERS=("$HOME/.config/verlihub" "$HOME/.verlihub" "/etc/verlihub" "$PREFIX/etc/verlihub");
+	GETENT=$(which getent);
+	if [ -n $GETENT ]; then
+		VH_USER_DIR=$($GETENT passwd verlihub | awk -F: '{print $6}');
+		if [ -n "$VH_USER_DIR" ]; then
+			FOLDERS+=("$VH_USER_DIR");
+		fi
+	fi
+	POSSIBLE_FOLDER=();
+	DIALOG_OPTIONS=();
+	I=1;
+	for f in ${FOLDERS[@]}; do
+		echo "$f";
+		if [ -e "$f/dbconfig" ]; then
+			POSSIBLE_FOLDER[$I]=$f;
+			IS_DEF="off";
+			if [ $I == "1" ]; then IS_DEF="on"; fi
+			DIALOG_OPTIONS+=($I $f $IS_DEF);
+			I=$(expr $I + 1);
+		fi
+	done
 	IS_CHOOSEN_FOLDER_OK=false
 	until $IS_CHOOSEN_FOLDER_OK;
 	do
 		$DIALOG --title "$1"\
 			--cancel-label "Quit" \
 			--radiolist "You need to specify hub with configuration folder. Move using [UP] [DOWN], [Space] to select a item" 14 80 17\
-			"1" "/etc/verlihub" "on"\
-			"2" "$HOME/.verlihub" "off"\
-			"3" "$PREFIX/etc/verlihub" "off"\
+			${DIALOG_OPTIONS[@]}\
 			"Other" "Choose path where put config file" "off" 2>$_TEMP
 
 		OPT=${?}
@@ -97,14 +116,13 @@ function _choose_folder() #title, #message
 			_quit;
 		fi
 	
-		CHOOSEN_FOLDER=`cat $_TEMP`
+		CHOOSEN_FOLDER=`cat $_TEMP`;
 		# Get selected folder
-		case $CHOOSEN_FOLDER in
-			"1") CHOOSEN_FOLDER="/etc/verlihub";;
-			"2") CHOOSEN_FOLDER="$HOME/.verlihub";;
-			"3") CHOOSEN_FOLDER="$PREFIX/etc/verlihub";;
-			"Other") $DIALOG --title "$TITLE" --dselect "$HOME" 25 60 2>$_TEMP && CHOOSEN_FOLDER=`cat $_TEMP` || _quit;;
-		esac
+		if [ -n "$POSSIBLE_FOLDER[$CHOOSEN_FOLDER]" ]; then
+			CHOOSEN_FOLDER=${POSSIBLE_FOLDER[$CHOOSEN_FOLDER]};
+		else
+			$DIALOG --title "$TITLE" --dselect "$HOME" 25 60 2>$_TEMP && CHOOSEN_FOLDER=`cat $_TEMP` || _quit;
+		fi
 		
 		if ! set_path $CHOOSEN_FOLDER > /dev/null 2>&1 ; then
 			$DIALOG --title "$TITLE" --msgbox "The path '$CHOOSEN_FOLDER' is not a valid config directory. Please specify another folder." 8 49
@@ -378,6 +396,41 @@ install() {
 		_quit;
 	fi
 
+	declare -A FOLDERS;
+	FCOUNT=0;
+	IS_VH_CFG_NEEDS_CHOWN=false
+	VH_USER_DIR=""
+
+	if [ $EUID -eq 0 ]; then
+		FCOUNT=$(expr $FCOUNT + 1);
+		FOLDERS[$FCOUNT]="/etc/verlihub";
+		FCOUNT=$(expr $FCOUNT + 1);
+		FOLDERS[$FCOUNT]="$PREFIX/etc/verlihub";
+		GETENT=$(which getent);
+		if [ -n $GETENT ]; then
+			VH_USER_DIR=$($GETENT passwd verlihub | awk -F: '{print $6}');
+			if [ -n "$VH_USER_DIR" ]; then
+				IS_VH_CFG_NEEDS_CHOWN=true
+				FCOUNT=$(expr $FCOUNT + 1);
+				FOLDERS[$FCOUNT]="$VH_USER_DIR";
+			fi
+		fi
+	else
+		$DIALOG --msgbox "Run vh_gui as root if you want to perfom system-wide setup" 5 45
+		FCOUNT=$(expr $FCOUNT + 1);
+		FOLDERS[$FCOUNT]="$HOME/.config/verlihub";
+		if [ -d "$HOME/.verlihub" ]; then
+			FCOUNT=$(expr $FCOUNT + 1);
+			FOLDERS[$FCOUNT]="$HOME/.verlihub";
+		fi
+	fi
+	FOLDERS_OPTIONS=();
+	for i in `seq 1 $FCOUNT`; do
+		local IS_DEF="off";
+		if [ $i == "1" ]; then IS_DEF="on"; fi
+		FOLDERS_OPTIONS+=($i ${FOLDERS[$i]} $IS_DEF);
+	done
+
 	# Select path where to put verlihub config file
 	IS_CHOOSEN_FOLDER_OK=false
 	until $IS_CHOOSEN_FOLDER_OK;
@@ -385,9 +438,7 @@ install() {
 		$DIALOG --title "Verlihub's config folder"\
 			--cancel-label "Quit" \
 			--radiolist "You need to choose a place for the configuration files. Move using [UP] [DOWN], [Space] to select a item" 14 80 17\
-			"1" "/etc/verlihub" "on"\
-			"2" "$HOME/.verlihub" "off"\
-			"3" "$PREFIX/etc/verlihub" "off"\
+			${FOLDERS_OPTIONS[*]}\
 			"Other" "Choose path where put config file" "off" 2>$_TEMP
 
 		OPT=${?}
@@ -397,12 +448,11 @@ install() {
 	
 		CHOOSEN_FOLDER=`cat $_TEMP`
 		# Get selected folder
-		case $CHOOSEN_FOLDER in
-			"1") CHOOSEN_FOLDER="/etc/verlihub";;
-			"2") CHOOSEN_FOLDER="$HOME/.verlihub";;
-			"3") CHOOSEN_FOLDER="$PREFIX/etc/verlihub";;
-			"Other") $DIALOG --title "Verlihub's config folder" --dselect "$HOME" 25 60 2>$_TEMP && CHOOSEN_FOLDER=`cat $_TEMP` || _quit;;
-		esac
+		if [ -n "${FOLDERS[$CHOOSEN_FOLDER]}" ]; then
+			CHOOSEN_FOLDER="${FOLDERS[$CHOOSEN_FOLDER]}";
+		else
+			$DIALOG --title "Verlihub's config folder" --dselect "$HOME" 25 60 2>$_TEMP && CHOOSEN_FOLDER=`cat $_TEMP` || _quit;
+		fi
 		
 		CHOOSEN_FOLDER_NOT_EXISTS=false
 		if [ -d $CHOOSEN_FOLDER ]; then
@@ -444,15 +494,20 @@ install() {
 	echo "db_data = $MYSQL_DB_NAME" >> $CONFIG
 	echo "db_user = $MYSQL_USER" >> $CONFIG
 	echo "db_pass = $MYSQL_PASSWORD" >> $CONFIG
-	
+
 	$DIALOG --title "Verlihub's config folder" --msgbox "Config file has been successfully written in '$CONFIG'. Now they will be created other directories and files." 7 60
-	
+
 	$DIALOG --infobox "Copy files and accessing to MySQL server; this could take some times..." 5 45
 	# Import other files from verlihub directory
 	cp $DATADIR/config/* $CHOOSEN_FOLDER
 	mkdir -p $CHOOSEN_FOLDER/plugins
 	mkdir -p $CHOOSEN_FOLDER/scripts
         ln -s $PLUGINDIR/libplug_pi.so $CHOOSEN_FOLDER/plugins
+
+    if $IS_VH_CFG_NEEDS_CHOWN && [ "$CHOOSEN_FOLDER" == "$VH_USER_DIR" ]; then
+		chown -R verlihub "$CHOOSEN_FOLDER";
+		chmod 0750 "$CHOOSEN_FOLDER";
+	fi
 
 	# Check if file has been created correctly
 	[ -f $CONFIG ] && CONFIG_EXISTS=true || CONFIG_EXISTS=false

--- a/scripts/vh_lib.in
+++ b/scripts/vh_lib.in
@@ -105,9 +105,17 @@ function _register() # nickname, class, password, input_password_crypt, reg_date
 function get_path_from_defaults()
 {
 	CONFIG_DIR="/etc/verlihub"
-	[ -d $PREFIX/etc/verlihub ] && CONFIG_DIR="$PREFIX/etc/verlihub"
-	[ -d ./.verlihub ] && CONFIG_DIR="./.verlihub"
-	[ -d ~/.verlihub ] && CONFIG_DIR="${HOME}/.verlihub"
+	GETENT=$(which getent);
+	if [ -n $GETENT ]; then
+		VH_USER_DIR=$($GETENT passwd verlihub | awk -F: '{print $6}');
+		if [ -n "$VH_USER_DIR" ] && [ -e "$VH_USER_DIR/dbconfig" ]; then
+			CONFIG_DIR="$VH_USER_DIR";
+		fi
+	fi
+	[ -e $PREFIX/etc/verlihub/dbconfig ]  && CONFIG_DIR="$PREFIX/etc/verlihub"
+	[ -e ./.verlihub/dbconfig ] && CONFIG_DIR="./.verlihub"
+	[ -e ~/.verlihub/dbconfig ] && CONFIG_DIR="${HOME}/.verlihub"
+	[ -e ~/.config/verlihub/dbconfig ] && CONFIG_DIR="${HOME}/.config/verlihub"
 }
 
 # Check if path is correct or not and set it as config directory; 
@@ -121,7 +129,6 @@ function set_path() #path_to_be_checked, #print_searching
 		fi
 		get_path_from_defaults
 	fi
-
 	if [ -d "$CONFIG_DIR" ] && [ -f "$CONFIG_DIR/dbconfig" ]; then
 		export VERLIHUB_CFG=$CONFIG_DIR
 		return 0;		


### PR DESCRIPTION
Big batch of changes:
1. Changing default users directory from ~/.verlihub to ~/.config/verlihub
~/.verlihub is supported if exists.
2. While installation ( vh | vh_gui --install) detecting the user who is running the script. If root - offering only system paths, otherwise only in user's home.
3. More intelligent selection of  "default" folder, considering not only folder exist-ans, but also dbconfig in it .
4 . Support for configuring system user *verlihub* (if presents in system), can be configured under root.