### PR TITLE
Reload functionality improved. Verbosity flag support.

### DIFF
--- a/scripts/vh.in
+++ b/scripts/vh.in
@@ -49,6 +49,7 @@ help_me()
 	echo_s "  -i, --install" $RED && echo -e "\t\t\t\tConfigure Verlihub for a new hub"
 	echo_s "  -r, --run" $RED && echo -e "\t[path_to_dbconfig] \tRun the hub from the given dbconfig path"
 	echo_s "  -q, --restart" $RED && echo -e "\t[path_to_dbconfig] \tRestart the hub from the given dbconfig path"
+	echo_s "  -R, --reload" $RED && echo -e "\t[path_to_dbconfig] \tForce hub to reload it's configuration and caches"
 	echo_s "  -s, --stop" $RED && echo -e "\t[path_to_dbconfig] \tStop the hub from the given dbconfig path"
 	echo_s "  -t, --status" $RED && echo -e "\t[path_to_dbconfig] \tCheck if hub is running or not"
 	echo_s "  -g, --geoip" $RED && echo -e "\t\t\t\tUpdate GeoIP"
@@ -219,6 +220,35 @@ function kill_hub() # path_to_dbconfig
 	rm -f "$CONFIG_DIR/pid"
 	sleep 2
 	echo " Done"
+}
+
+function reload_hub()
+{
+	# Check config directory
+	if ! set_path $1 ; then
+		exit 1;
+	fi
+
+	# Check if hub is already running
+	if ! _is_hub_running $CONFIG_DIR ; then
+		echo_s "-- Hub with config path '$CONFIG_DIR' is not running\n" $RED
+		if [ -f $PID_FILE ]; then
+			if [ -w $PID_FILE ]; then
+				rm -f $PID_FILE
+			else
+				echo_s "-- PID file $PID_FILE already exists. Can't remove it, please do it manually\n" $RED
+			fi
+		fi
+		return 1;
+	fi
+	
+	_get_pid $CONFIG_DIR
+	echo -n "-- Reloading verlihub (PID: $PID_RESULT)..."
+	if ! kill -SIGHUP $PID_RESULT > /dev/null 2>&1 ; then
+		echo_s " USER HAS NO RIGHT TO SEND SIGNALS TO THE PROCESS\n" $RED
+		exit 1;
+	fi
+	echo_s "[OK]\n" $GREEN
 }
 
 # Check if hub is running or not
@@ -883,6 +913,7 @@ case "_$1" in
 	"_-r"|"_--run")		shift; run_hub $@;;
 	"_-s"|"_--stop")	shift; kill_hub $@;;
 	"_-q"|"_--restart")	shift; kill_hub $1; run_hub "$1" "restart";;
+	"_-R"|"_--reload")	shift; reload_hub $@;;
 	"_-t"|"_--status")	shift; hub_status $1;;
 	"_-g"|"_--geoip")	shift; update_geoip $1;;
 	"_-a"|"_--autoload")shift; autoload $@;;

--- a/scripts/vh_daemon.in
+++ b/scripts/vh_daemon.in
@@ -23,6 +23,7 @@ shift
 PID=
 
 trap "stop_hub" SIGQUIT SIGTERM SIGKILL SIGINT
+trap "reload_hub" SIGHUP
 
 function start_hub()
 {
@@ -38,6 +39,16 @@ function stop_hub()
 		echo Killing hub..
 		kill -3 $PID
 		echo
+	fi
+}
+
+function reload_hub()
+{
+	if [ "_$PID" != "_" ]; then
+		echo Reloading hub..
+		kill -SIGHUP $PID
+		echo
+		wait $PID
 	fi
 }
 

--- a/scripts/vh_daemon.in
+++ b/scripts/vh_daemon.in
@@ -29,8 +29,11 @@ function start_hub()
 {
 	$VERLIHUB $* &
 	PID=$!
-	wait $PID
-	return $?
+	while ps -p $PID  2>&1 >/dev/null; do # this cycle is needed to stay here after SIGHUP
+		wait $PID
+		TMP=$?
+	done
+	return $TMP
 }
 
 function stop_hub()
@@ -48,7 +51,6 @@ function reload_hub()
 		echo Reloading hub..
 		kill -SIGHUP $PID
 		echo
-		wait $PID
 	fi
 }
 

--- a/scripts/vh_gui.in
+++ b/scripts/vh_gui.in
@@ -140,6 +140,7 @@ help_me()
 	echo_s "  -i, --install" $RED && echo -e "\t\t\t\tConfigure Verlihub for a new hub"
 	echo_s "  -r, --run" $RED && echo -e "\t[path_to_dbconfig] \tRun the hub from the given dbconfig path"
 	echo_s "  -q, --restart" $RED && echo -e "\t[path_to_dbconfig] \tRestart the hub from the given dbconfig path"
+	echo_s "  -R, --reload" $RED && echo -e "\t[path_to_dbconfig] \tForce hub to reload it's configuration and caches"
 	echo_s "  -s, --stop" $RED && echo -e "\t[path_to_dbconfig] \tStop the hub from the given dbconfig path"
 	echo_s "  -t, --status" $RED && echo -e "\t[path_to_dbconfig] \tCheck if hub is running or not"
 	echo_s "  -v, --version" $RED && echo -e "\t\t\t\tPrint version information"
@@ -271,6 +272,39 @@ function kill_hub() # restart
 	if [ "$1" != "restart" ]; then
 		$DIALOG --title "$TITLE" --msgbox "Done" 6 30
 	fi
+}
+
+function reload_hub() # restart
+{
+	# Set title
+	if [ "$1" != "restart" ]; then
+		TITLE="Stop a hub"
+	else
+		TITLE="Restart hub"
+	fi	
+
+	_choose_folder $TITLE
+
+	# Check if hub is already running
+	if ! _is_hub_running $CONFIG_DIR ; then
+		$DIALOG --title "$TITLE" --msgbox "Hub with config path '$CONFIG_DIR' is not running." 8 49
+		if [ -f $PID_FILE ]; then
+			if [ -w $PID_FILE ]; then
+				rm -f $PID_FILE
+			else
+				$DIALOG --title "$TITLE" --msgbox "PID file $PID_FILE already exists. Can't remove it, please do it manually" 8 49
+			fi
+		fi
+		return 1;
+	fi
+	_get_pid $CONFIG_DIR
+	$DIALOG --infobox "Reloading verlihub (PID: $PID_RESULT)..." 4 45
+	if ! kill -SIGHUP $PID_RESULT > /dev/null 2>&1 ; then
+		$DIALOG --title "$TITLE" --msgbox "Error: USER HAS NO RIGHT TO SEND SIGNALS TO THE PROCESS. Please run vh_gui --reload as root" 7 50 
+		_quit;
+	fi
+	
+	$DIALOG --title "$TITLE" --msgbox "Done" 6 30
 }
 
 hub_status()
@@ -590,6 +624,7 @@ case "_$1" in
 	"_-r"|"_--run")		run_hub;;
 	"_-s"|"_--stop")	kill_hub;;
 	"_-q"|"_--restart")	kill_hub "restart"; run_hub "restart";;
+	"_-R"|"_--reload")	reload_hub;;
 	"_-t"|"_--status")	hub_status;;
 # 	"_-g"|"_--geoip")	shift; update_geoip $1;;
 # 	"_-a"|"_--autoload")shift; autoload $@;;

--- a/src/cdcconsole.cpp
+++ b/src/cdcconsole.cpp
@@ -1099,15 +1099,8 @@ int cDCConsole::CmdProtect(istringstream &cmd_line, cConnDC *conn)
 
 int cDCConsole::CmdReload(istringstream &cmd_line, cConnDC *conn)
 {
-	ostringstream os;
-
-	os << _("Reloading triggers, custom redirects, configuration and registration list cache.");
-	mTriggers->ReloadAll();
-	mRedirects->ReloadAll();
-	mOwner->mC.Load();
-	mOwner->DCPublicHS(os.str().c_str(),conn);
-	if (mOwner->mC.use_reglist_cache)
-		mOwner->mR->UpdateCache();
+	mOwner->DCPublicHS(_("Reloading triggers, custom redirects, configuration and registration list cache.") ,conn);
+	mOwner->Reload();
 	return 1;
 }
 

--- a/src/cserverdc.cpp
+++ b/src/cserverdc.cpp
@@ -2266,5 +2266,15 @@ void cServerDC::CtmToHubClearList()
 	mCtmToHubList.clear();
 }
 
+void cServerDC::Reload()
+{
+	mC.Load();
+	mCo->mTriggers->ReloadAll();
+	mCo->mRedirects->ReloadAll();
+	mCo->mDCClients->ReloadAll();
+	if (mC.use_reglist_cache)
+		mR->UpdateCache();
+}
+
 	}; // namespace nServer
 }; // namespace nVerliHub

--- a/src/cserverdc.h
+++ b/src/cserverdc.h
@@ -646,6 +646,9 @@ class cServerDC : public cAsyncSocketServer
 		int CtmToHubRefererList(string &list);
 		void CtmToHubClearList();
 
+		// Reloads configuration and all caches.
+		void Reload();
+
 protected: // Protected methods
 	/**
 	* This method is called when user is logged in.


### PR DESCRIPTION
This commit move reload functionality from *cdcconsole* to *cserverdc*.
Support for reload via SIGHUP enabled
New commands for vh scripts will force verlihub to reread config and update caches:
vh -R| --reload
ch_gui -R| --reload

Verbosity flag:
new command line argument -v | --verbose
Will increase log_level for 1 per entrance.

*For example:*
We have log_level variables set to 1.
runnging hub like `verlihub -v` will increase runtime log_level to 2.
`verlihub -vv` will increase runtime log_level to 3.
This won't affect log_level settings in db.
Call to `!set log_level` will discard this effect.